### PR TITLE
feat(portfolio): replace mock data with real-time portfolio API integration

### DIFF
--- a/backend/api/routes/routes.go
+++ b/backend/api/routes/routes.go
@@ -64,6 +64,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.DELETE(constants.TransactionHistoryEndpoint, handlersProvider.Transactions.DeleteTransactions)
 
 		// Portfolio routes
+		api.GET("/portfolio/holdings", handlersProvider.Portfolio.GetAllHoldings)
 		api.GET("/portfolio/holdings/:symbol", handlersProvider.Portfolio.GetSingleHoldingBasicInfo)
 	}
 

--- a/backend/internal/models/portfolio.go
+++ b/backend/internal/models/portfolio.go
@@ -18,8 +18,14 @@ type SingleHolding struct {
 
 // SingleHoldingResponse represents the response structure for stock basic info
 type SingleHoldingResponse struct {
-	Data      SingleHolding `json:"data"`
-	Timestamp time.Time     `json:"timestamp"`
+	SingleHolding
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// AllHoldingsResponse represents the response structure for all holdings
+type AllHoldingsResponse struct {
+	Holdings  []SingleHolding `json:"holdings"`
+	Timestamp time.Time       `json:"timestamp"`
 }
 
 // PortfolioAnalysisType represents the type of analysis requested

--- a/backend/internal/repositories/transaction_repository.go
+++ b/backend/internal/repositories/transaction_repository.go
@@ -90,11 +90,6 @@ func (r *TransactionRepository) UpdateByID(id uuid.UUID, updates map[string]inte
 	return r.db.Model(&models.Transaction{}).Where("transaction_id = ?", id).Updates(updates).Error
 }
 
-// DeleteByID soft deletes a transaction by transaction_id (UUID)
-func (r *TransactionRepository) DeleteByID(id uuid.UUID) error {
-	return r.db.Where("transaction_id = ?", id).Delete(&models.Transaction{}).Error
-}
-
 // DeleteByIDAndUserID soft deletes a transaction by transaction_id and user_id (UUID)
 func (r *TransactionRepository) DeleteByIDAndUserID(id uuid.UUID, userID uuid.UUID) error {
 	return r.db.Where("transaction_id = ? AND user_id = ?", id, userID).Delete(&models.Transaction{}).Error

--- a/backend/internal/services/transaction_service.go
+++ b/backend/internal/services/transaction_service.go
@@ -50,16 +50,6 @@ func (s *TransactionService) CreateTransactions(userID uuid.UUID, transactions [
 	return s.transactionRepo.CreateMany(transactions)
 }
 
-// GetPortfolioSummary returns portfolio summary for a user
-func (s *TransactionService) GetPortfolioSummary(userID uuid.UUID) (map[string]interface{}, error) {
-	return s.transactionRepo.GetPortfolioSummaryByUserID(userID)
-}
-
-// GetSymbolHoldings returns current holdings for a user grouped by symbol
-func (s *TransactionService) GetSymbolHoldings(userID uuid.UUID) ([]map[string]interface{}, error) {
-	return s.transactionRepo.GetSymbolHoldingsByUserID(userID)
-}
-
 // GetTransactionsWithFilter retrieves transactions with advanced filtering (business logic method)
 func (s *TransactionService) GetTransactionsWithFilter(filter TransactionFilter) ([]models.Transaction, error) {
 	return s.transactionRepo.GetWithFilters(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import ProcessingPage from '@/pages/ProcessingPage'
 import SettingsPage from '@/pages/SettingsPage'
 import ManualTransactionPage from '@/pages/ManualTransactionPage'
 import ManualDataReviewPage from '@/pages/ManualDataReviewPage'
+import SingleHoldingDetailPage from '@/pages/SingleHoldingDetailPage'
 import UploadImageGuard from '@/components/UploadImageGuard'
 
 function App() {
@@ -52,6 +53,10 @@ function App() {
                   <Route
                     path={ROUTES.TRANSACTIONS_MANUAL_REVIEW}
                     element={<ManualDataReviewPage />}
+                  />
+                  <Route
+                    path={`${ROUTES.PORTFOLIO_HOLDING}/:symbol`}
+                    element={<SingleHoldingDetailPage />}
                   />
                   <Route path={ROUTES.SETTINGS} element={<SettingsPage />} />
                 </Route>

--- a/frontend/src/components/dashboard/PositionCard.tsx
+++ b/frontend/src/components/dashboard/PositionCard.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useEffect, useState, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
   Table,
@@ -8,14 +9,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { formatCurrency } from '@/utils'
+import { formatCurrency, formatPercent } from '@/utils'
+import { ROUTES } from '@/constants'
+import { fetchAllHoldings } from '@/services/portfolio.service'
+import { useToast } from '@/hooks/useToast'
 
 interface Position {
   symbol: string
   quantity: number
   last: number
-  changeAmount: number
-  changePercent: number
   marketValue: number
   unitCost: number
   totalCost: number
@@ -24,6 +26,12 @@ interface Position {
 }
 
 export const PositionCard: React.FC = () => {
+  const { showToast } = useToast()
+  const [positions, setPositions] = useState<Position[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const didFetch = useRef(false)
+
   const formatNumber = (num: number, decimals: number = 2) => {
     return new Intl.NumberFormat('en-US', {
       minimumFractionDigits: decimals,
@@ -31,96 +39,99 @@ export const PositionCard: React.FC = () => {
     }).format(num)
   }
 
-  const formatPercent = (percent: number) => {
-    const sign = percent >= 0 ? '+' : ''
-    return `${sign}${percent.toFixed(2)}%`
-  }
-
   const formatChange = (amount: number) => {
     const sign = amount >= 0 ? '+' : ''
     return `${sign}${amount.toFixed(2)}`
   }
 
-  // Mock data based on the screenshot
-  const positions: Position[] = [
-    {
-      symbol: 'GOOGL',
-      quantity: 32.29027,
-      last: 174.15,
-      changeAmount: 0.61,
-      changePercent: 0.35,
-      marketValue: 5623.35,
-      unitCost: 170.40923,
-      totalCost: 5502.56,
-      gainLossAmount: 120.79,
-      gainLossPercent: 2.2,
-    },
-    {
-      symbol: 'NVDA',
-      quantity: 61.37719,
-      last: 157.33,
-      changeAmount: 2.31,
-      changePercent: 1.49,
-      marketValue: 9656.47,
-      unitCost: 118.03799,
-      totalCost: 7244.84,
-      gainLossAmount: 2411.63,
-      gainLossPercent: 33.29,
-    },
-    {
-      symbol: 'ON',
-      quantity: 9.36329,
-      last: 53.27,
-      changeAmount: -0.38,
-      changePercent: -0.71,
-      marketValue: 498.78,
-      unitCost: 53.40003,
-      totalCost: 500.0,
-      gainLossAmount: -1.22,
-      gainLossPercent: -0.24,
-    },
-    {
-      symbol: 'PL',
-      quantity: 83,
-      last: 6.52,
-      changeAmount: 0.46,
-      changePercent: 7.59,
-      marketValue: 541.16,
-      unitCost: 6.03916,
-      totalCost: 501.25,
-      gainLossAmount: 39.91,
-      gainLossPercent: 7.96,
-    },
-    {
-      symbol: 'QQQ',
-      quantity: 22.94481,
-      last: 549.38,
-      changeAmount: 3.16,
-      changePercent: 0.58,
-      marketValue: 12605.42,
-      unitCost: 506.55508,
-      totalCost: 11622.81,
-      gainLossAmount: 982.61,
-      gainLossPercent: 8.45,
-    },
-    {
-      symbol: 'SGOV',
-      quantity: 42.84301,
-      last: 100.68,
-      changeAmount: 0.03,
-      changePercent: 0.03,
-      marketValue: 4313.43,
-      unitCost: 100.64792,
-      totalCost: 4312.06,
-      gainLossAmount: 1.37,
-      gainLossPercent: 0.03,
-    },
-  ]
+  useEffect(() => {
+    if (didFetch.current) return
+    didFetch.current = true
+
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+
+        const response = await fetchAllHoldings()
+
+        // Transform API data to match our component interface
+        const transformedPositions: Position[] = response.holdings.map((holding) => ({
+          symbol: holding.symbol,
+          quantity: holding.total_quantity,
+          last: holding.current_price,
+          marketValue: holding.market_value,
+          unitCost: holding.unit_cost,
+          totalCost: holding.total_cost,
+          gainLossAmount: holding.unrealized_gain_loss,
+          gainLossPercent: holding.simple_return_rate,
+        }))
+
+        setPositions(transformedPositions)
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to fetch holdings data'
+        setError(errorMessage)
+        showToast({
+          title: 'Error',
+          message: errorMessage,
+          type: 'error',
+        })
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [showToast])
 
   const getChangeColor = (value: number) => {
     if (value > 0) return 'text-profit'
     if (value < 0) return 'text-loss'
     return 'text-muted-foreground'
+  }
+
+  if (loading) {
+    return (
+      <Card className="bg-card border-border/50">
+        <CardHeader>
+          <CardTitle className="text-lg text-foreground">Positions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center h-32">
+            <div className="text-muted-foreground">Loading positions...</div>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error) {
+    return (
+      <Card className="bg-card border-border/50">
+        <CardHeader>
+          <CardTitle className="text-lg text-foreground">Positions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center h-32">
+            <div className="text-muted-foreground">Failed to load positions</div>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (positions.length === 0) {
+    return (
+      <Card className="bg-card border-border/50">
+        <CardHeader>
+          <CardTitle className="text-lg text-foreground">Positions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center h-32">
+            <div className="text-muted-foreground">No positions found</div>
+          </div>
+        </CardContent>
+      </Card>
+    )
   }
 
   return (
@@ -145,7 +156,12 @@ export const PositionCard: React.FC = () => {
               {positions.map((position) => (
                 <TableRow key={position.symbol}>
                   <TableCell className="">
-                    <span className="text-primary font-medium">{position.symbol}</span>
+                    <Link
+                      to={`${ROUTES.PORTFOLIO_HOLDING}/${position.symbol}`}
+                      className="text-primary font-medium underline"
+                    >
+                      {position.symbol}
+                    </Link>
                   </TableCell>
                   <TableCell className="text-right">{formatNumber(position.quantity, 5)}</TableCell>
                   <TableCell className="text-right">{formatCurrency(position.last)}</TableCell>

--- a/frontend/src/components/ui/breadcrumb.tsx
+++ b/frontend/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+interface BreadcrumbItem {
+  label: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+}
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ items }) => {
+  return (
+    <nav className="flex" aria-label="Breadcrumb">
+      <ol className="inline-flex items-center space-x-1 md:space-x-3">
+        {items.map((item, index) => (
+          <li key={index} className="inline-flex items-center">
+            {index > 0 && (
+              <svg
+                className="w-3 h-3 text-muted-foreground mx-1"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 6 10"
+              >
+                <path
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="m1 9 4-4-4-4"
+                />
+              </svg>
+            )}
+            {item.href ? (
+              <Link
+                to={item.href}
+                className="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-primary transition-colors"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className="text-sm font-medium text-foreground">{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 // Re-export all UI components for easier imports
 export { Button } from './button'
 export { buttonVariants } from './button-variants'
+export { Breadcrumb } from './breadcrumb'
 export { Checkbox } from './checkbox'
 export { ConfirmationModal } from './confirmation-modal'
 export { ImageViewerModal } from './ImageViewerModal'

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   TRANSACTIONS_UPLOAD_REVIEW: '/transactions/upload-review',
   TRANSACTIONS_MANUAL_ADD: '/transactions/manual-add',
   TRANSACTIONS_MANUAL_REVIEW: '/transactions/manual-review',
+  PORTFOLIO_HOLDING: '/portfolio/holding',
   SETTINGS: '/settings',
   UI_DEMO: '/ui-demo',
   CONTACT: '/contact',

--- a/frontend/src/pages/SingleHoldingDetailPage.tsx
+++ b/frontend/src/pages/SingleHoldingDetailPage.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useState, useCallback, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { Card, CardContent } from '@/components/ui/card'
+import { Breadcrumb } from '@/components/ui/breadcrumb'
+import { ROUTES } from '@/constants'
+import { formatCurrency, formatPercent } from '@/utils'
+import { fetchSingleHoldingBasicInfo } from '@/services/portfolio.service'
+import { useToast } from '@/hooks/useToast'
+
+interface HoldingDetailData {
+  symbol: string
+  companyName: string
+  currentPrice: number
+  priceChange: number
+  priceChangePercent: number
+  totalQuantity: number
+  totalCost: number
+  marketValue: number
+  unitCost: number
+  simpleReturn: number
+  annualizedReturn: number
+  realizedGainLoss: number
+  unrealizedGainLoss: number
+}
+
+export default function SingleHoldingDetailPage() {
+  const { symbol } = useParams<{ symbol: string }>()
+  const navigate = useNavigate()
+  const { showToast } = useToast()
+  const [holdingData, setHoldingData] = useState<HoldingDetailData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const didFetch = useRef(false)
+
+  const fetchData = useCallback(async () => {
+    if (!symbol) {
+      setError('Symbol not provided')
+      setLoading(false)
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await fetchSingleHoldingBasicInfo(symbol.toUpperCase(), 'basic')
+
+      // Transform API data to match our component interface
+      setHoldingData({
+        symbol: response.symbol,
+        companyName: response.symbol,
+        currentPrice: response.current_price,
+        priceChange: 0, // Mock data - will need to be provided by API
+        priceChangePercent: response.simple_return_rate,
+        totalQuantity: response.total_quantity,
+        totalCost: response.total_cost,
+        marketValue: response.market_value,
+        unitCost: response.unit_cost,
+        simpleReturn: response.simple_return_rate,
+        annualizedReturn: response.annualized_return_rate,
+        realizedGainLoss: response.realized_gain_loss,
+        unrealizedGainLoss: response.unrealized_gain_loss,
+      })
+    } catch (err) {
+      console.error('Failed to fetch holding data:', err)
+
+      let errorMessage = 'Failed to fetch holding data'
+
+      if (err instanceof Error) {
+        if (
+          err.message.includes('no transactions found') ||
+          err.message.includes('no current holdings')
+        ) {
+          errorMessage = `No holdings found for ${symbol.toUpperCase()}`
+        } else if (err.message.includes('Unable to fetch current price data')) {
+          errorMessage = 'Unable to fetch current price data. Please try again later.'
+        } else if (err.message.includes('User not authenticated')) {
+          errorMessage = 'Please log in to view your holdings'
+          // Redirect to login page after a short delay
+          setTimeout(() => {
+            navigate(ROUTES.LOGIN)
+          }, 2000)
+        } else {
+          errorMessage = err.message
+        }
+      }
+
+      setError(errorMessage)
+      showToast({
+        type: 'error',
+        title: 'Failed to Load Holding',
+        message: errorMessage,
+        duration: 5000,
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [symbol, navigate, showToast])
+
+  useEffect(() => {
+    if (didFetch.current) return
+    didFetch.current = true
+    fetchData()
+  }, [fetchData])
+
+  const breadcrumbItems = [
+    { label: 'Dashboard', href: ROUTES.DASHBOARD },
+    { label: 'Position', href: ROUTES.DASHBOARD },
+    { label: symbol?.toUpperCase() || '' },
+  ]
+
+  const formatValue = (value: number) => {
+    const sign = value >= 0 ? '+' : ''
+    return `${sign}${formatCurrency(Math.abs(value))}`
+  }
+
+  const getValueColor = (value: number) => {
+    return value >= 0 ? 'text-profit' : 'text-loss'
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto py-6 px-4">
+          <div className="flex justify-center items-center h-64">
+            <span className="text-muted-foreground">Loading holding details...</span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !holdingData) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto py-6 px-4">
+          {/* Breadcrumb Navigation */}
+          <Breadcrumb items={breadcrumbItems} />
+
+          <div className="flex flex-col items-center justify-center h-64 space-y-4">
+            <span className="text-destructive text-lg font-medium">
+              {error || 'Holding not found'}
+            </span>
+            <div className="flex gap-3">
+              <button
+                onClick={() => fetchData()}
+                className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
+              >
+                Try Again
+              </button>
+              <button
+                onClick={() => navigate(ROUTES.DASHBOARD)}
+                className="px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/90 transition-colors"
+              >
+                Back to Dashboard
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto py-6 px-4 space-y-6">
+        {/* Breadcrumb Navigation */}
+        <Breadcrumb items={breadcrumbItems} />
+
+        {/* Stock Title Section */}
+        <div className="flex flex-col md:flex-row md:items-center md:gap-6 space-y-2 md:space-y-0">
+          <h1 className="text-3xl font-bold text-foreground flex-shrink-0">
+            {holdingData.companyName}
+          </h1>
+          <div
+            className={`flex items-center gap-3 ${getValueColor(holdingData.priceChangePercent)}`}
+          >
+            <span className="text-2xl font-bold">{formatCurrency(holdingData.currentPrice)}</span>
+            <span className={'text-lg font-medium'}>
+              ({formatPercent(holdingData.priceChangePercent)})
+            </span>
+          </div>
+        </div>
+
+        {/* Chart Placeholder - will be implemented later */}
+        <Card>
+          <CardContent>
+            <div className="h-64 bg-muted/20 rounded-lg flex items-center justify-center">
+              <span className="text-muted-foreground">
+                Interactive Stock Chart (To be implemented)
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Holdings Information Section */}
+        <Card>
+          <CardContent>
+            <h2 className="text-xl font-semibold text-foreground mb-6">Holding</h2>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-16">
+              {/* Left Column */}
+              <div className="space-y-4">
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Total Quantity</span>
+                  <span className="font-medium text-foreground">
+                    {holdingData.totalQuantity.toLocaleString()} shares
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Total Cost</span>
+                  <span className="font-medium text-foreground">
+                    {formatCurrency(holdingData.totalCost)}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Simple Return</span>
+                  <span className={`font-medium ${getValueColor(holdingData.simpleReturn)}`}>
+                    {formatPercent(holdingData.simpleReturn)}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Realized Gain/Loss</span>
+                  <span className={`font-medium ${getValueColor(holdingData.realizedGainLoss)}`}>
+                    {formatValue(holdingData.realizedGainLoss)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Right Column */}
+              <div className="space-y-4">
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Market Value</span>
+                  <span className="font-medium text-foreground">
+                    {formatCurrency(holdingData.marketValue)}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Unit Cost</span>
+                  <span className="font-medium text-foreground">
+                    {formatCurrency(holdingData.unitCost)}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Annualized Return</span>
+                  <span className={`font-medium ${getValueColor(holdingData.annualizedReturn)}`}>
+                    {formatPercent(holdingData.annualizedReturn)}
+                  </span>
+                </div>
+
+                <div className="flex justify-between items-center">
+                  <span className="text-muted-foreground">Unrealized Gain/Loss</span>
+                  <span className={`font-medium ${getValueColor(holdingData.unrealizedGainLoss)}`}>
+                    {formatValue(holdingData.unrealizedGainLoss)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/portfolio.service.ts
+++ b/frontend/src/services/portfolio.service.ts
@@ -4,7 +4,7 @@
 import { API_ENDPOINTS } from '@/constants/api'
 import { apiClient } from '@/lib/api-client'
 
-export interface SingleHoldingBasicInfo {
+export interface SingleHoldingBasicInfoResponse {
   symbol: string
   total_quantity: number
   total_cost: number
@@ -18,8 +18,8 @@ export interface SingleHoldingBasicInfo {
   timestamp: string
 }
 
-export interface SingleHoldingBasicInfoResponse {
-  data: SingleHoldingBasicInfo
+export interface AllHoldingsResponse {
+  holdings: SingleHoldingBasicInfoResponse[]
   timestamp: string
 }
 
@@ -52,6 +52,22 @@ export async function fetchSingleHoldingBasicInfo(
     return result.data!
   } catch (error) {
     console.error('Error fetching stock basic info:', error)
+    throw error
+  }
+}
+
+/**
+ * Fetch all portfolio holdings for the current user
+ * @returns Promise with all holdings data
+ */
+export async function fetchAllHoldings(): Promise<AllHoldingsResponse> {
+  const url = API_ENDPOINTS.PORTFOLIO.HOLDINGS
+
+  try {
+    const response = await apiClient.get<AllHoldingsResponse>(url)
+    return response.data
+  } catch (error) {
+    console.error('Error fetching all holdings:', error)
     throw error
   }
 }

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,3 +1,8 @@
+// Format percent values with sign
+export function formatPercent(value: number): string {
+  const sign = value >= 0 ? '+' : ''
+  return `${sign}${value.toFixed(2)}%`
+}
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
@@ -43,4 +48,20 @@ export function toSnakeCase<T extends object>(obj: T): Record<string, unknown> {
       typeof value === 'object' && value !== null ? toSnakeCase(value) : value,
     ])
   )
+}
+
+export function snakeToCamel<T>(obj: T): T {
+  if (Array.isArray(obj)) {
+    return obj.map(snakeToCamel) as unknown as T
+  } else if (obj !== null && typeof obj === 'object') {
+    return Object.entries(obj as Record<string, unknown>).reduce(
+      (acc, [key, value]) => {
+        const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+        ;(acc as Record<string, unknown>)[camelKey] = snakeToCamel(value)
+        return acc
+      },
+      {} as Record<string, unknown>
+    ) as T
+  }
+  return obj
 }


### PR DESCRIPTION
This commit implements comprehensive portfolio holdings functionality by replacing mock data with real backend API integration. The implementation includes both backend endpoints and frontend components for displaying portfolio positions and individual holding details.

Backend changes:
- Add GetAllHoldings API endpoint with proper authentication
- Create AllHoldingsResponse model for structured data
- Implement bulk portfolio holdings retrieval in service layer
- Fix UUID type assertions in authentication middleware

Frontend changes:
- Replace PositionCard mock data with real API calls
- Create SingleHoldingDetailPage with breadcrumb navigation
- Add comprehensive error handling and loading states
- Implement formatPercent utility function
- Use useRef to prevent duplicate API requests in React Strict Mode