### PR TITLE
refactor(price-service,portfolio): unify API key and total return

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ STOCK_API_PROVIDER=alpha_vantage
 DEFAULT_TTL_MINUTES=60
 RATE_LIMIT_REQUESTS=100
 RATE_LIMIT_WINDOW_MINUTES=1
-API_KEY=
+PRICE_SERVICE_API_KEY=
 
 # Price Service - Exterior Stock Price Provider Configuration
 ALPHA_VANTAGE_BASE_URL=https://www.alphavantage.co/query

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ npm-debug.log
 backend/backend
 backend/transaction-tracker
 backend/transaction-tracker-test
+backend/main
 price_service/price_service
 price_service/price-service
 price_service/tmp

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -30,10 +30,10 @@ type Config struct {
 
 // PriceServiceConfig holds configuration for Price Service integration
 type PriceServiceConfig struct {
-	BaseURL    string
-	APIKey     string
-	Timeout    time.Duration
-	MaxRetries int
+	BaseURL            string
+	PriceServiceApiKey string
+	Timeout            time.Duration
+	MaxRetries         int
 }
 
 // Load loads the configuration from environment variables
@@ -90,10 +90,10 @@ func Load() (*Config, error) {
 
 	// Price Service configuration
 	priceServiceConfig := PriceServiceConfig{
-		BaseURL:    getEnvOrDefault("PRICE_SERVICE_BASE_URL", "http://localhost:8081"),
-		APIKey:     getEnvOrDefault("PRICE_SERVICE_API_KEY", ""),
-		Timeout:    time.Duration(getEnvOrDefaultInt("PRICE_SERVICE_TIMEOUT", 30)) * time.Second,
-		MaxRetries: getEnvOrDefaultInt("PRICE_SERVICE_MAX_RETRIES", 3),
+		BaseURL:            getEnvOrDefault("PRICE_SERVICE_URL", "http://localhost:8081"),
+		PriceServiceApiKey: getEnvOrDefault("PRICE_SERVICE_API_KEY", ""),
+		Timeout:            time.Duration(getEnvOrDefaultInt("PRICE_SERVICE_TIMEOUT", 30)) * time.Second,
+		MaxRetries:         getEnvOrDefaultInt("PRICE_SERVICE_MAX_RETRIES", 3),
 	}
 
 	return &Config{

--- a/backend/internal/models/portfolio.go
+++ b/backend/internal/models/portfolio.go
@@ -10,7 +10,7 @@ type SingleHolding struct {
 	UnitCost             float64 `json:"unit_cost"`
 	CurrentPrice         float64 `json:"current_price"`
 	MarketValue          float64 `json:"market_value"`
-	SimpleReturnRate     float64 `json:"simple_return_rate"`
+	TotalReturnRate      float64 `json:"total_return_rate"`
 	AnnualizedReturnRate float64 `json:"annualized_return_rate"`
 	RealizedGainLoss     float64 `json:"realized_gain_loss"`
 	UnrealizedGainLoss   float64 `json:"unrealized_gain_loss"`

--- a/backend/internal/provider/price_service_client.go
+++ b/backend/internal/provider/price_service_client.go
@@ -106,7 +106,7 @@ func NewPriceServiceClient(cfg *config.Config) PriceServiceClient {
 		},
 		circuitBreaker: NewCircuitBreaker(5, 1*time.Minute), // 5 failures, 1 minute reset
 		baseURL:        cfg.PriceService.BaseURL,
-		apiKey:         cfg.PriceService.APIKey,
+		apiKey:         cfg.PriceService.PriceServiceApiKey,
 		lastHealthy:    time.Now(),
 	}
 }

--- a/backend/internal/provider/price_service_test.go
+++ b/backend/internal/provider/price_service_test.go
@@ -54,10 +54,10 @@ func TestPriceServiceClient_GetCurrentPrices(t *testing.T) {
 
 	cfg := &config.Config{
 		PriceService: config.PriceServiceConfig{
-			BaseURL:    server.URL,
-			APIKey:     "test-key",
-			Timeout:    30 * time.Second,
-			MaxRetries: 3,
+			BaseURL:            server.URL,
+			PriceServiceApiKey: "test-key",
+			Timeout:            30 * time.Second,
+			MaxRetries:         3,
 		},
 	}
 
@@ -94,10 +94,10 @@ func TestPriceServiceClient_GetCurrentPrices_Error(t *testing.T) {
 
 	cfg := &config.Config{
 		PriceService: config.PriceServiceConfig{
-			BaseURL:    server.URL,
-			APIKey:     "test-key",
-			Timeout:    30 * time.Second,
-			MaxRetries: 0, // No retries for this test
+			BaseURL:            server.URL,
+			PriceServiceApiKey: "test-key",
+			Timeout:            30 * time.Second,
+			MaxRetries:         0, // No retries for this test
 		},
 	}
 
@@ -131,10 +131,10 @@ func TestPriceServiceClient_HealthCheck(t *testing.T) {
 
 	cfg := &config.Config{
 		PriceService: config.PriceServiceConfig{
-			BaseURL:    server.URL,
-			APIKey:     "test-key",
-			Timeout:    30 * time.Second,
-			MaxRetries: 3,
+			BaseURL:            server.URL,
+			PriceServiceApiKey: "test-key",
+			Timeout:            30 * time.Second,
+			MaxRetries:         3,
 		},
 	}
 
@@ -173,10 +173,10 @@ func TestPriceServiceManager_GetCurrentPrice(t *testing.T) {
 
 	cfg := &config.Config{
 		PriceService: config.PriceServiceConfig{
-			BaseURL:    server.URL,
-			APIKey:     "test-key",
-			Timeout:    30 * time.Second,
-			MaxRetries: 3,
+			BaseURL:            server.URL,
+			PriceServiceApiKey: "test-key",
+			Timeout:            30 * time.Second,
+			MaxRetries:         3,
 		},
 	}
 

--- a/backend/internal/repositories/transaction_repository.go
+++ b/backend/internal/repositories/transaction_repository.go
@@ -81,7 +81,7 @@ func (r *TransactionRepository) GetByIDAndUserID(id uuid.UUID, userID uuid.UUID)
 // GetByUserID retrieves all transactions for a user by user_id (UUID)
 func (r *TransactionRepository) GetByUserID(userID uuid.UUID) ([]models.Transaction, error) {
 	var transactions []models.Transaction
-	err := r.db.Where("user_id = ?", userID).Preload("User").Find(&transactions).Error
+	err := r.db.Where("user_id = ?", userID).Order("transaction_date ASC").Preload("User").Find(&transactions).Error
 	return transactions, err
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "@reduxjs/toolkit": "^2.8.2",
     "axios": "^1.10.0",
     "class-variance-authority": "^0.7.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.7
+        version: 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@reduxjs/toolkit':
         specifier: ^2.8.2
         version: 2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
@@ -424,6 +427,21 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.3':
+    resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
+
+  '@floating-ui/react-dom@2.1.5':
+    resolution: {integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -497,6 +515,22 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@radix-ui/primitive@1.1.2':
+    resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -506,8 +540,78 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.10':
+    resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-label@2.1.7':
     resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.7':
+    resolution: {integrity: sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.4':
+    resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -540,6 +644,98 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/react-tooltip@1.2.7':
+    resolution: {integrity: sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@reduxjs/toolkit@2.8.2':
     resolution: {integrity: sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==}
@@ -2603,6 +2799,23 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.3':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2672,8 +2885,45 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
@@ -2681,6 +2931,44 @@ snapshots:
   '@radix-ui/react-label@2.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -2702,6 +2990,85 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@reduxjs/toolkit@2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:

--- a/frontend/src/components/dashboard/PositionCard.tsx
+++ b/frontend/src/components/dashboard/PositionCard.tsx
@@ -9,6 +9,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { Tooltip } from '@/components/ui/tooltip'
+import { tooltipCopywriting } from '@/constants/tooltipCopywriting'
 import { formatCurrency, formatPercent } from '@/utils'
 import { ROUTES } from '@/constants'
 import { fetchAllHoldings } from '@/services/portfolio.service'
@@ -65,7 +67,7 @@ export const PositionCard: React.FC = () => {
           unitCost: holding.unit_cost,
           totalCost: holding.total_cost,
           gainLossAmount: holding.unrealized_gain_loss,
-          gainLossPercent: holding.simple_return_rate,
+          gainLossPercent: holding.total_return_rate,
           annualizedReturnRate: holding.annualized_return_rate,
         }))
 
@@ -150,8 +152,10 @@ export const PositionCard: React.FC = () => {
                 <TableHead className="text-right">Quantity</TableHead>
                 <TableHead className="text-right">Last</TableHead>
                 <TableHead className="text-right">Market Value</TableHead>
-                <TableHead className="text-right">Gain/Loss($)</TableHead>
-                <TableHead className="text-right">Gain/Loss(%)</TableHead>
+                <TableHead className="text-right">Unrealized G/L($)</TableHead>
+                <TableHead className="text-right">
+                  <Tooltip content={tooltipCopywriting['Total Return']}>Total Return</Tooltip>
+                </TableHead>
                 <TableHead className="text-right">Annualized Return</TableHead>
               </TableRow>
             </TableHeader>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,60 @@
+import * as RadixTooltip from '@radix-ui/react-tooltip'
+import React from 'react'
+import type { ReactNode } from 'react'
+
+interface TooltipProps {
+  content: ReactNode
+  children: ReactNode
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ content, children }) => (
+  <RadixTooltip.Provider>
+    <RadixTooltip.Root delayDuration={200}>
+      <RadixTooltip.Trigger asChild>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+          {children}
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              border: '1px solid #fefefe',
+              color: '#fefefe',
+              fontSize: 11,
+              fontWeight: 600,
+              cursor: 'pointer',
+              background: 'none',
+            }}
+            aria-label="Tooltip info"
+            tabIndex={0}
+          >
+            i
+          </span>
+        </span>
+      </RadixTooltip.Trigger>
+      <RadixTooltip.Portal>
+        <RadixTooltip.Content
+          side="top"
+          align="center"
+          style={{
+            background: 'rgba(0,0,0,0.85)',
+            color: '#fff',
+            padding: '6px 12px',
+            borderRadius: 4,
+            fontSize: 14,
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            maxWidth: '90vw',
+            minWidth: '120px',
+            zIndex: 100,
+            whiteSpace: 'pre-line',
+          }}
+        >
+          {content}
+        </RadixTooltip.Content>
+      </RadixTooltip.Portal>
+    </RadixTooltip.Root>
+  </RadixTooltip.Provider>
+)

--- a/frontend/src/constants/tooltipCopywriting.ts
+++ b/frontend/src/constants/tooltipCopywriting.ts
@@ -1,0 +1,8 @@
+export const tooltipCopywriting: Record<string, string> = {
+  'Total Return': '(Realized G/L + Unrealized G/L) / Total Invested Amount * 100%',
+  'Total Value': 'Current market value of your holding.',
+  'Unit Cost': 'Average cost per share based on weighted average method.',
+  'Annualized Return': 'Annualized rate of return (XIRR) based on cash flows.',
+  'Realized Gain/Loss': 'Profit or loss from completed transactions.',
+  'Unrealized Gain/Loss': 'Profit or loss from current holdings not yet sold.',
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -20,10 +20,10 @@ const DashboardPage: React.FC = () => {
         {/* Dashboard Grid */}
         <div className="space-y-6">
           {/* Portfolio Summary - Full Width */}
-          <PortfolioSummaryCard />
+          {/* <PortfolioSummaryCard /> */}
 
           {/* Total Value Chart - Full Width */}
-          <TotalValueChartCard />
+          {/* <TotalValueChartCard /> */}
 
           {/* Positions - Full Width */}
           <PositionCard />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {
-  PortfolioSummaryCard,
+  // PortfolioSummaryCard,
   // AssetAllocationCard,
   // TopPerformersCard,
   PositionCard,
-  TotalValueChartCard,
+  // TotalValueChartCard,
 } from '@/components/dashboard'
 import { Title } from '@/components/ui/title'
 

--- a/frontend/src/pages/SingleHoldingDetailPage.tsx
+++ b/frontend/src/pages/SingleHoldingDetailPage.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
+import { Tooltip } from '@/components/ui/tooltip'
+import { tooltipCopywriting } from '@/constants/tooltipCopywriting'
 import { useParams, useNavigate } from 'react-router-dom'
 import { Card, CardContent } from '@/components/ui/card'
 import { Breadcrumb } from '@/components/ui/breadcrumb'
@@ -16,7 +18,7 @@ interface HoldingDetailData {
   totalCost: number
   marketValue: number
   unitCost: number
-  simpleReturn: number
+  totalReturnRate: number
   annualizedReturn: number
   realizedGainLoss: number
   unrealizedGainLoss: number
@@ -49,12 +51,12 @@ export default function SingleHoldingDetailPage() {
         symbol: response.symbol,
         companyName: response.symbol,
         currentPrice: response.current_price,
-        priceChangePercent: response.simple_return_rate,
+        priceChangePercent: response.total_return_rate,
         totalQuantity: response.total_quantity,
         totalCost: response.total_cost,
         marketValue: response.market_value,
         unitCost: response.unit_cost,
-        simpleReturn: response.simple_return_rate,
+        totalReturnRate: response.total_return_rate,
         annualizedReturn: response.annualized_return_rate,
         realizedGainLoss: response.realized_gain_loss,
         unrealizedGainLoss: response.unrealized_gain_loss,
@@ -214,9 +216,11 @@ export default function SingleHoldingDetailPage() {
                 </div>
 
                 <div className="flex justify-between items-center">
-                  <span className="text-muted-foreground">Simple Return</span>
-                  <span className={`font-medium ${getValueColor(holdingData.simpleReturn)}`}>
-                    {formatPercent(holdingData.simpleReturn)}
+                  <Tooltip content={tooltipCopywriting['Total Return']}>
+                    <span className="text-muted-foreground">Total Return</span>
+                  </Tooltip>
+                  <span className={`font-medium ${getValueColor(holdingData.totalReturnRate)}`}>
+                    {formatPercent(holdingData.totalReturnRate)}
                   </span>
                 </div>
 

--- a/frontend/src/pages/TransactionHistoryPage.tsx
+++ b/frontend/src/pages/TransactionHistoryPage.tsx
@@ -568,10 +568,11 @@ export default function TransactionHistoryPage() {
                               ${transaction.price}
                             </TableCell>
                             <TableCell className="text-right text-muted-foreground">
+                              {transaction.trade_type === TRADE_TYPE.SELL ? '-' : ''}
                               {transaction.quantity}
                             </TableCell>
                             <TableCell className="text-right">
-                              {transaction.trade_type === TRADE_TYPE.SELL ? '-' : ''}$
+                              {transaction.trade_type === TRADE_TYPE.BUY ? '-' : ''}$
                               {transaction.amount}
                             </TableCell>
                             <TableCell className="text-right">{transaction.currency}</TableCell>

--- a/frontend/src/services/portfolio.service.ts
+++ b/frontend/src/services/portfolio.service.ts
@@ -12,7 +12,7 @@ export interface SingleHoldingBasicInfoResponse {
   unit_cost: number
   current_price: number
   market_value: number
-  simple_return_rate: number
+  total_return_rate: number
   annualized_return_rate: number
   realized_gain_loss: number
   unrealized_gain_loss: number

--- a/price_service/api/middlewares/auth.go
+++ b/price_service/api/middlewares/auth.go
@@ -32,6 +32,7 @@ func APIKeyMiddleware(validAPIKey string) gin.HandlerFunc {
 		}
 
 		apiKey := c.GetHeader("X-API-Key")
+
 		if apiKey == "" {
 			c.JSON(http.StatusUnauthorized, models.ErrorResponse{
 				Success: false,

--- a/price_service/internal/config/config.go
+++ b/price_service/internal/config/config.go
@@ -55,7 +55,7 @@ func Load() (*Config, error) {
 	config := &Config{
 		Server: ServerConfig{
 			Port:   getEnv("PORT", "8081"),
-			APIKey: getEnv("API_KEY", ""),
+			APIKey: getEnv("PRICE_SERVICE_API_KEY", ""),
 		},
 		Redis: RedisConfig{
 			Host:     getEnv("REDIS_HOST", "localhost"),


### PR DESCRIPTION
- Refactor backend and price_service to use PRICE_SERVICE_API_KEY consistently.
- Rename simpleReturnRate to totalReturnRate in backend, frontend, and models. Update tooltip copywriting and UI to reflect total return calculation.